### PR TITLE
Allow for replace paths in modules.txt file

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,11 +67,19 @@ func main() {
 		line := scanner.Text()
 
 		if line[0] == 35 {
+			// split input to use replace path if there is one
+			parts := strings.Split(line, "=>")
+			// remove leading spaces
+			line = strings.TrimLeft(
+				parts[len(parts)-1],
+				" ",
+			)
 			s := strings.Split(line, " ")
 
+			// use "relative" indexes, a replace line doesn't have a leading # value in its parts
 			mod = &Mod{
-				ImportPath: s[1],
-				Version:    s[2],
+				ImportPath: s[len(s)-2],
+				Version:    s[len(s)-1],
 			}
 			mod.Dir = pkgModPath(mod.ImportPath, mod.Version)
 

--- a/main.go
+++ b/main.go
@@ -67,13 +67,6 @@ func main() {
 		line := scanner.Text()
 
 		if line[0] == 35 {
-			// split input to use replace path if there is one
-			parts := strings.Split(line, "=>")
-			// remove leading spaces
-			line = strings.TrimLeft(
-				parts[len(parts)-1],
-				" ",
-			)
 			s := strings.Split(line, " ")
 
 			// use "relative" indexes, a replace line doesn't have a leading # value in its parts


### PR DESCRIPTION
If the modules.txt file contains a replace path like:

```
# github.com/foo/bar v1.0.0 => github.com/foobar/pkg v2.1.3
```

Then `modvendor` complains about non-existing paths (naturally). This change parses the part after the `=>` separator instead, and carries on from there.