### PR TITLE
Add -include flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ $ GO111MODULE=on go mod vendor
 $ modvendor -copy="**/*.c **/*.h **/*.proto" -v
 ```
 
+If there are folders that are untracked by `vendor/modules.txt`, include them
+via the `-include` flag. For example:
+
+```
+$ GO111MODULE=on go mod vendor
+$ modvendor \
+  -copy="**/*.c **/*.h **/*.proto" \
+  -include="github.com/tensorflow/tensorflow/tensorflow/c" \
+  -v
+```
+
 ## LICENSE
 
 MIT

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,9 +16,10 @@ import (
 )
 
 var (
-	flags       = flag.NewFlagSet("modvendor", flag.ExitOnError)
-	copyPatFlag = flags.String("copy", "", "copy files matching glob pattern to ./vendor/ (ie. modvendor -copy=\"**/*.c **/*.h **/*.proto\")")
-	verboseFlag = flags.Bool("v", false, "verbose output")
+	flags               = flag.NewFlagSet("modvendor", flag.ExitOnError)
+	copyPatFlag         = flags.String("copy", "", "copy files matching glob pattern to ./vendor/, e.g., modvendor -copy=\"**/*.c **/*.h **/*.proto\"")
+	includePackagesFlag = flags.String("include", "", "additional packages untracked in vendor/modules.txt, e.g., modvendor -include=\"github.com/tensorflow/tensorflow/tensorflow/c\"")
+	verboseFlag         = flags.Bool("v", false, "verbose output")
 )
 
 type Mod struct {
@@ -29,34 +32,42 @@ type Mod struct {
 	VendorList    map[string]bool // files to vendor
 }
 
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func main() {
-	flags.Parse(os.Args[1:])
+	must(flags.Parse(os.Args[1:]))
 
 	// Ensure go.mod file exists and we're running from the project root,
 	// and that ./vendor/modules.txt file exists.
 	cwd, err := os.Getwd()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	must(err)
+
+	// Ensure that a go.mod exists in the project.
+	modPath := filepath.Join(cwd, "go.mod")
+	if _, err := os.Stat(modPath); os.IsNotExist(err) {
+		must(fmt.Errorf("%s not found. Run `go mod vendor` and try again.", modPath))
 	}
-	if _, err := os.Stat(filepath.Join(cwd, "go.mod")); os.IsNotExist(err) {
-		fmt.Println("Whoops, cannot find `go.mod` file")
-		os.Exit(1)
-	}
+
+	// Ensure that a vendor/modules.txt exists in the project.
 	modtxtPath := filepath.Join(cwd, "vendor", "modules.txt")
 	if _, err := os.Stat(modtxtPath); os.IsNotExist(err) {
-		fmt.Println("Whoops, cannot find vendor/modules.txt, first run `go mod vendor` and try again")
-		os.Exit(1)
+		must(fmt.Errorf("%s not found. Run `go mod vendor` and try again.", modtxtPath))
 	}
 
-	// Prepare vendor copy patterns
+	// Prepare vendor copy patterns.
 	copyPat := strings.Split(strings.TrimSpace(*copyPatFlag), " ")
 	if len(copyPat) == 0 {
-		fmt.Println("Whoops, -copy argument is empty, nothing to copy.")
-		os.Exit(1)
+		must(errors.New("-copy argument is empty."))
 	}
 
-	// Parse/process modules.txt file of pkgs
+	// Prepare additional packages.
+	includedPackages := strings.Split(strings.TrimSpace(*includePackagesFlag), " ")
+
+	// Parse/process modules.txt file of pkgs.
 	f, _ := os.Open(modtxtPath)
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
@@ -68,7 +79,7 @@ func main() {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if line[0] == 35 {
+		if line[0] == 35 { // i.e., #
 			s := strings.Split(line, " ")
 
 			mod = &Mod{
@@ -90,13 +101,12 @@ func main() {
 			}
 
 			if _, err := os.Stat(mod.Dir); os.IsNotExist(err) {
-				fmt.Printf("Error! %q module path does not exist, check $GOPATH/pkg/mod\n", mod.Dir)
-				os.Exit(1)
+				must(fmt.Errorf("%s module path does not exist. Check $GOPATH/pkg/mod.", mod.Dir))
 			}
 
-			// Build list of files to module path source to project vendor folder
+			// Build list of files to module path source to
+			// project vendor folder.
 			mod.VendorList = buildModVendorList(copyPat, mod)
-
 			modules = append(modules, mod)
 
 			continue
@@ -105,12 +115,19 @@ func main() {
 		mod.Pkgs = append(mod.Pkgs, line)
 	}
 
-	// Filter out files not part of the mod.Pkgs
+	// Filter out files not part of the mod.Pkgs.
 	for _, mod := range modules {
 		if len(mod.VendorList) == 0 {
 			continue
 		}
-		for vendorFile, _ := range mod.VendorList {
+
+		for _, pkg := range includedPackages {
+			if strings.HasPrefix(pkg, mod.ImportPath) {
+				mod.Pkgs = append(mod.Pkgs, pkg)
+			}
+		}
+
+		for vendorFile := range mod.VendorList {
 			for _, subpkg := range mod.Pkgs {
 				path := filepath.Join(mod.Dir, importPathIntersect(mod.ImportPath, subpkg))
 
@@ -127,7 +144,7 @@ func main() {
 		}
 	}
 
-	// Copy mod vendor list files to ./vendor/
+	// Copy mod vendor list files to ./vendor.
 	for _, mod := range modules {
 		for vendorFile := range mod.VendorList {
 			x := strings.Index(vendorFile, mod.Dir)
@@ -143,7 +160,7 @@ func main() {
 				fmt.Printf("vendoring %s\n", localPath)
 			}
 
-			os.MkdirAll(filepath.Dir(localFile), os.ModePerm)
+			must(os.MkdirAll(filepath.Dir(localFile), os.ModePerm))
 			if _, err := copyFile(vendorFile, localFile); err != nil {
 				fmt.Printf("Error! %s - unable to copy file %s\n", err.Error(), vendorFile)
 				os.Exit(1)
@@ -158,8 +175,7 @@ func buildModVendorList(copyPat []string, mod *Mod) map[string]bool {
 	for _, pat := range copyPat {
 		matches, err := zglob.Glob(filepath.Join(mod.Dir, pat))
 		if err != nil {
-			fmt.Println("Error! glob match failure:", err)
-			os.Exit(1)
+			must(fmt.Errorf("glob match failure: %v", err))
 		}
 
 		for _, m := range matches {


### PR DESCRIPTION
This patch adds an -include flag which takes a space-separated string of package paths that should be considered against the globs provided to `-copy`.

The use-case encountered in my own context was converting a project that used `github.com/tensorflow/tensorflow`, which `go mod` fails to record the `github.com/tensorflow/tensorflow/tensorflow/c` folder that contains the header files necessary for compilation.