### PR TITLE
Fix relative replaces by using an absolute path as mod dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/goware/modvendor
 
 require github.com/mattn/go-zglob v0.0.0-20180803001819-2ea3427bfa53
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -83,8 +83,19 @@ func main() {
 			// Handle "replace" in module file if any
 			if len(s) > 3 && s[3] == "=>" {
 				mod.SourcePath = s[4]
-				mod.SourceVersion = s[5]
-				mod.Dir = pkgModPath(mod.SourcePath, mod.SourceVersion)
+
+				// Handle replaces with a relative target. For example:
+				// "replace github.com/status-im/status-go/protocol => ./protocol"
+				if strings.HasPrefix(s[4], ".") || strings.HasPrefix(s[4], "/") {
+					mod.Dir, err = filepath.Abs(s[4])
+					if err != nil {
+						fmt.Printf("invalid relative path: %v", err)
+						os.Exit(1)
+					}
+				} else {
+					mod.SourceVersion = s[5]
+					mod.Dir = pkgModPath(mod.SourcePath, mod.SourceVersion)
+				}
 			} else {
 				mod.Dir = pkgModPath(mod.ImportPath, mod.Version)
 			}


### PR DESCRIPTION
For relative replaces like `replace github.com/status-im/status-go/protocol => ./protocol` the current logic panics. 

There is [another PR addressing this issue](https://github.com/goware/modvendor/pull/8) but it does not work for me because I need to vendor files also from the relative replaces.