### PR TITLE
Add support for golang 1.14

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,9 @@ func main() {
 
 		if line[0] == 35 {
 			s := strings.Split(line, " ")
+			if len(s) != 3 || s[1] == "explicit" {
+				continue
+			}
 
 			mod = &Mod{
 				ImportPath: s[1],


### PR DESCRIPTION
In golang 1.14 was changed modules.txt. This PR prevent panic.
Example file:
```
# github.com/g3n/engine v0.1.1-0.20200227161744-78541849abfd
## explicit
github.com/g3n/engine/app
github.com/g3n/engine/audio/al
github.com/g3n/engine/audio/vorbis
github.com/g3n/engine/camera
github.com/g3n/engine/core
github.com/g3n/engine/geometry
github.com/g3n/engine/gls
github.com/g3n/engine/graphic
github.com/g3n/engine/gui
github.com/g3n/engine/gui/assets
github.com/g3n/engine/gui/assets/icon
github.com/g3n/engine/light
github.com/g3n/engine/material
github.com/g3n/engine/math32
github.com/g3n/engine/renderer
github.com/g3n/engine/renderer/shaders
github.com/g3n/engine/text
github.com/g3n/engine/texture
github.com/g3n/engine/util/helper
github.com/g3n/engine/util/logger
github.com/g3n/engine/window
# github.com/go-gl/glfw v0.0.0-20200222043503-6f7a984d4dc4
## explicit
github.com/go-gl/glfw/v3.2/glfw
# github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
## explicit
github.com/golang/freetype/raster
github.com/golang/freetype/truetype
# golang.org/x/image v0.0.0-20200119044424-58c23975cae1
## explicit
golang.org/x/image/font
golang.org/x/image/math/fixed
# gopkg.in/yaml.v2 v2.2.8
## explicit
gopkg.in/yaml.v2
```