### PR TITLE
handle replace syntax in ./vendor/modules.txt correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 
 		if line[0] == 35 {
 			s := strings.Split(line, " ")
-			if len(s) != 3 || s[1] == "explicit" {
+			if (len(s) != 6 && len(s) != 3) || s[1] == "explicit" {
 				continue
 			}
 


### PR DESCRIPTION
The len(s) != 3 check does not account for replace syntax, which has 6
lines.