### PR TITLE
add flag that copies additional directories into ./vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ $ GO111MODULE=on go mod vendor
 $ modvendor -copy="**/*.c **/*.h **/*.proto" -v
 ```
 
+If you have additional directories that you wish to copy which are not specified
+under `./vendor/modules.txt`, use the `-include` flag with multiple values separated
+by commas, e.g.:
+
+```
+$ GO111MODULE=on go mod vendor
+$ modvendor -copy="**/*.c **/*.h **/*.proto" -v -include="github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/rpc,github.com/prometheus/client_model"
+```
+
 ## LICENSE
 
 MIT

--- a/main.go
+++ b/main.go
@@ -17,6 +17,10 @@ var (
 	flags       = flag.NewFlagSet("modvendor", flag.ExitOnError)
 	copyPatFlag = flags.String("copy", "", "copy files matching glob pattern to ./vendor/ (ie. modvendor -copy=\"**/*.c **/*.h **/*.proto\")")
 	verboseFlag = flags.Bool("v", false, "verbose output")
+	includeFlag = flags.String(
+		"include",
+		"",
+		`specifies additional directories to copy into ./vendor/ which are not specified in ./vendor/modules.txt. Multiple directories can be included by comma separation e.g. -include:github.com/a/b/dir1,github.com/a/b/dir1/dir2`)
 )
 
 type Mod struct {
@@ -55,6 +59,7 @@ func main() {
 		fmt.Println("Whoops, -copy argument is empty, nothing to copy.")
 		os.Exit(1)
 	}
+	additionalDirsToInclude := strings.Split(*includeFlag, ",")
 
 	// Parse/process modules.txt file of pkgs
 	f, _ := os.Open(modtxtPath)
@@ -99,6 +104,12 @@ func main() {
 
 			// Build list of files to module path source to project vendor folder
 			mod.VendorList = buildModVendorList(copyPat, mod)
+			// Append directories we need to also include which may not be in vendor/modules.txt.
+			for _, dir := range additionalDirsToInclude {
+				if strings.HasPrefix(dir, mod.ImportPath) {
+					mod.Pkgs = append(mod.Pkgs, dir)
+				}
+			}
 
 			modules = append(modules, mod)
 


### PR DESCRIPTION
add flag that copies additional directories into ./vendor

In the case of a package like `github.com/prometheus/client_model`,
there are protobuf files in `github.com/prometheus/client_model` which
do not get copied at all even with this tool as it is not specified in
`./vendor/modules.txt`.

Add the ability to do this by adding an `-include` flag, which
takes in `<dir_to_copy>` fields separated by commas.

(Example of this in CockroachDB: cockroachdb/cockroach#49447)

