### PR TITLE
fix "module path does not exist, check $GOPATH/pkg/mod"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goware/modvendor
+module github.com/zouguangxian/modvendor
 
 require github.com/mattn/go-zglob v0.0.2-0.20191112051448-a8912a37f9e7
 

--- a/main.go
+++ b/main.go
@@ -104,6 +104,17 @@ func main() {
 				mod.Dir = pkgModPath(mod.ImportPath, mod.Version)
 			}
 
+			ignore := true
+			for _, dir := range additionalDirsToInclude {
+				if strings.HasPrefix(dir, mod.ImportPath) {
+					ignore = false
+				}
+			}
+
+			if ignore {
+				continue
+			}
+
 			if _, err := os.Stat(mod.Dir); os.IsNotExist(err) {
 				fmt.Printf("Error! %q module path does not exist, check $GOPATH/pkg/mod\n", mod.Dir)
 				os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 
 		if line[0] == 35 {
 			s := strings.Split(line, " ")
-			if (len(s) != 6 && len(s) != 3) || s[1] == "explicit" {
+			if (len(s) != 5 && len(s) != 6 && len(s) != 3) || s[1] == "explicit" {
 				continue
 			}
 
@@ -90,9 +90,16 @@ func main() {
 			}
 			// Handle "replace" in module file if any
 			if len(s) > 3 && s[3] == "=>" {
-				mod.SourcePath = s[4]
-				mod.SourceVersion = s[5]
-				mod.Dir = pkgModPath(mod.SourcePath, mod.SourceVersion)
+				switch(len(s)) {
+				case 5:
+					mod.SourcePath = s[4]
+					mod.SourceVersion = s[2]
+					mod.Dir = filepath.Join(cwd, s[4])
+				case 6:
+					mod.SourcePath = s[4]
+					mod.SourceVersion = s[5]
+					mod.Dir = pkgModPath(mod.SourcePath, mod.SourceVersion)
+				}				
 			} else {
 				mod.Dir = pkgModPath(mod.ImportPath, mod.Version)
 			}


### PR DESCRIPTION
support replace directive with local path in go.mod
fix "module path does not exist, check $GOPATH/pkg/mod"